### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Whatodo
 =======
 [![Build Status](https://travis-ci.org/masterkoppa/whatodo.svg?branch=master)](https://travis-ci.org/masterkoppa/whatodo)
 [![Coverage Status](https://coveralls.io/repos/masterkoppa/whatodo/badge.svg?branch=master)](https://coveralls.io/r/masterkoppa/whatodo?branch=master)
-[![Latest Version](https://pypip.in/version/whatodo/badge.svg)](https://pypi.python.org/pypi/whatodo/)
-[![Downloads](https://pypip.in/download/whatodo/badge.svg)](https://pypi.python.org/pypi/whatodo/)
+[![Latest Version](https://img.shields.io/pypi/v/whatodo.svg)](https://pypi.python.org/pypi/whatodo/)
+[![Downloads](https://img.shields.io/pypi/dm/whatodo.svg)](https://pypi.python.org/pypi/whatodo/)
 
 # Description
 In software development and any other area of coding it is a common occerance to use comments 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20whatodo))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `whatodo`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.